### PR TITLE
Fix missing language support

### DIFF
--- a/ipn_payson.php
+++ b/ipn_payson.php
@@ -3,6 +3,11 @@
 $req['input'] = file_get_contents('php://input');
 
 require_once('includes/application_top.php');
+
+$_GET['main_page'] = 'checkout_process';
+$language_page_directory = DIR_WS_LANGUAGES . $_SESSION['language'] . '/';
+$directory_array = $template->get_template_part($code_page_directory, '/^header_php/');
+
 require_once( DIR_FS_CATALOG . 'includes/modules/payment/payson.php');
 require_once( DIR_FS_CATALOG . 'includes/modules/payment/payson/def.payson.php');
 

--- a/ipn_payson.php
+++ b/ipn_payson.php
@@ -53,4 +53,3 @@ $_SESSION["paysonToken"] = $token;
 $checkoutProcessFile = DIR_WS_MODULES . FILENAME_CHECKOUT_PROCESS . ".php";
 
 include($checkoutProcessFile);
-?>


### PR DESCRIPTION
Without loading the language components, any outgoing emails triggered by subsequent processing will not be generated properly.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/paysonab/module-payson-zencart/2)
<!-- Reviewable:end -->
